### PR TITLE
Access item by position in KombindAdapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.android_plugin_version = '3.1.1'
-    ext.kotlin_version = '1.2.40'
+    ext.kotlin_version = '1.2.41'
     repositories {
         google()
         jcenter()

--- a/kombind/src/main/java/com/umairjavid/kombind/ui/KombindAdapter.kt
+++ b/kombind/src/main/java/com/umairjavid/kombind/ui/KombindAdapter.kt
@@ -11,7 +11,7 @@ import com.umairjavid.kombind.BR
 import com.umairjavid.kombind.model.AdapterAction
 import com.umairjavid.kombind.model.MutableLiveArrayList
 
-abstract class KombindAdapter<V: KombindAdapter.ViewHolder>(private val items: MutableLiveArrayList<*>) : RecyclerView.Adapter<V>() {
+abstract class KombindAdapter<V: KombindAdapter.ViewHolder>(protected val items: MutableLiveArrayList<*>) : RecyclerView.Adapter<V>() {
     private lateinit var layoutInflater: LayoutInflater
     open val handler: Any? = null
     protected abstract fun getLayout(position: Int): Int
@@ -33,8 +33,6 @@ abstract class KombindAdapter<V: KombindAdapter.ViewHolder>(private val items: M
     override fun getItemCount() = items.size
 
     override fun getItemViewType(position: Int) = getLayout(position)
-
-    protected fun getItem(position: Int): Any? = items[position]
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): V {
         if (!::layoutInflater.isInitialized) layoutInflater = LayoutInflater.from(parent.context)

--- a/kombind/src/main/java/com/umairjavid/kombind/ui/KombindAdapter.kt
+++ b/kombind/src/main/java/com/umairjavid/kombind/ui/KombindAdapter.kt
@@ -34,6 +34,8 @@ abstract class KombindAdapter<V: KombindAdapter.ViewHolder>(private val items: M
 
     override fun getItemViewType(position: Int) = getLayout(position)
 
+    protected fun getItem(position: Int): Any? = items[position]
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): V {
         if (!::layoutInflater.isInitialized) layoutInflater = LayoutInflater.from(parent.context)
         return createViewHolder(DataBindingUtil.inflate(layoutInflater, viewType, parent, false))


### PR DESCRIPTION
@ujavid I'm using an adapter that has different views. I pass a super type in the adapter constructor `class AlbumAdapter(items: MutableLiveArrayList<AlbumAdapterItem>, override val handler: Any?) : KombindAdapter<KombindAdapter.ViewHolder>(items) {`

I have 2 classes `data class Album() : AlbumAdapterItem` and `data class AlbumFooter() : AlbumAdapterItem`. I'd like to do `override fun getLayout(position: Int) = if (item[position] is AlbumFooter) R.layout.item_album_footer else R.layout.item_album`

Does that make sense? Or did you think of another way to deal with this situation?

I could also do `override fun getLayout(position: Int) = if (position == itemCount - 1) R.layout.item_wedding_more else R.layout.item_wedding`. But I'd rather rely on the type than the position